### PR TITLE
New command to authenticate against trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,25 +68,15 @@ for it.
 
 First go to: https://trello.com/app-key to get your API Key and API Secret.
 
-In a bash compatible shell, run the following exports to config (configure
-with your data).
-
+Then call trellowarrior with the authenticate command :
 ```sh
-export TRELLO_API_KEY="your_api_key"
-export TRELLO_API_SECRET="your_api_secret"
-export TRELLO_NAME="TrelloWarrior"
-export TRELLO_EXPIRATION="30days"
+trellowarrior.py -c path/to/your/configfile authenticate --api-key your_api_key --api-key-secret your_api_secret --trello-name TrelloWarrior --expiration 30days
 ```
 
-Note: You can set the `TRELLO_EXPIRATION` to `1hour`, `1day`, `30days`,
+If the config file already exist, an error will be printed and the command will stop without doing anything.
+
+You can set the `TRELLO_EXPIRATION` to `1hour`, `1day`, `30days`,
 `never`. We recomend use `30days` for tests and `never` for daily use.
-
-Now run the Trello util script in the Virtualenv to get the token and token
-secret.
-
-```sh
-python trw/lib/python2.7/site-packages/trello/util.py
-```
 
 This return some like this.
 
@@ -122,7 +112,7 @@ Access Token:
 You may now access protected resources using the access tokens above.
 ```
 
-Finaly you have access tokens to put in TrelloWarrior config file.
+The config file is now initialized with the needed configuration variables.
 
 ## Configuration
 
@@ -133,6 +123,18 @@ You can place the config file with `trellowarrior.py`, in your home as
 `~/.trellowarrior.conf` or `~/.config/trellowarrior/trellowarrior.conf`, or
 set the configuration file path with `-c` or `--config` argument.
 
+To synchronize trello and task warrior, simply call trellowarrior with the sync command
+
+```sh 
+trellowarrior.py sync
+```
+
+You can also add a list of project(s) to synchronize :
+
+```sh 
+trellowarrior.py sync project1 project2
+```
+ 
 ### DEFAULT Section
 
 In the `DEFAULT` section, it is mandatory to set your Trello API key and

--- a/trellowarrior/main.py
+++ b/trellowarrior/main.py
@@ -43,6 +43,7 @@ def parse_config(config_file):
         if conf.has_section(sync_project):
             if conf.has_option(sync_project, 'tw_project_name') and conf.has_option(sync_project, 'trello_board_name'):
                 project = {}
+                project['project_name'] = sync_project
                 project['tw_project_name'] = conf.get(sync_project, 'tw_project_name')
                 project['trello_board_name'] = conf.get(sync_project, 'trello_board_name')
                 if conf.has_option(sync_project, 'trello_todo_list'):
@@ -413,27 +414,24 @@ def sync(args):
         config_file = args.config
 
     if parse_config(config_file):
-        if args.projects:
-            projects_list = args.projects
-        else:
-            projects_list = sync_projects
-        for project in projects_list:
-            # Get all Trello lists
-            trello_lists = get_trello_lists(project['trello_board_name'])
-            # Do sync Trello - Task Warrior
-            sync_trello_tw(trello_lists,
-                    project['tw_project_name'],
-                    project['trello_board_name'],
-                    project['trello_todo_list'],
-                    project['trello_doing_list'],
-                    project['trello_done_list'])
-            # Upload new Task Warrior tasks
-            upload_new_tw_tasks(trello_lists,
-                    project['tw_project_name'],
-                    project['trello_board_name'],
-                    project['trello_todo_list'],
-                    project['trello_doing_list'],
-                    project['trello_done_list'])
+        for project in sync_projects:
+            if len(args.projects) == 0 or project['project_name'] in args.projects:
+                # Get all Trello lists
+                trello_lists = get_trello_lists(project['trello_board_name'])
+                # Do sync Trello - Task Warrior
+                sync_trello_tw(trello_lists,
+                        project['tw_project_name'],
+                        project['trello_board_name'],
+                        project['trello_todo_list'],
+                        project['trello_doing_list'],
+                        project['trello_done_list'])
+                # Upload new Task Warrior tasks
+                upload_new_tw_tasks(trello_lists,
+                        project['tw_project_name'],
+                        project['trello_board_name'],
+                        project['trello_todo_list'],
+                        project['trello_doing_list'],
+                        project['trello_done_list'])
 
 def authenticate(args):
     """


### PR DESCRIPTION
This is a PR to open discussion about a new approach for the CLI. I have added some sub commands (for now sync and authenticate). This could have been done with options instead of subcommands, but I would like to add some other ones after that (ie one to add new project) and options to the existing one (ie name of project to sync, pull-push choice, ...)

If you are OK with this approach I will add some documentation to the commands and new methods.