### PR TITLE
Limit fetched boards to open ones

### DIFF
--- a/trellowarrior/main.py
+++ b/trellowarrior/main.py
@@ -81,7 +81,7 @@ def parse_config(config_file):
 def get_trello_boards():
     """ Get all Trello boards """
     trello_client = TrelloClient(api_key=trello_api_key, api_secret=trello_api_secret, token=trello_token, token_secret=trello_token_secret)
-    return trello_client.list_boards()
+    return trello_client.list_boards(board_filter="open")
 
 def get_trello_board(board_name):
     """


### PR DESCRIPTION
I have a lot of closed boards (I should do some cleanup) and list_boards was quite slow. Limiting the fetching to open boards has speed up the process.