### PR TITLE
Trello card member sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ uda.trelloid.type=string
 uda.trelloid.label=Trello ID
 uda.trellolistname.type=string
 uda.trellolistname.label=Trello List Name
+uda.trellomembers.type=string
+uda.trellomembers.label=Trello Members
 ```
 
 The first UDA `trelloid` is used to store the Trello Card ID and establish
@@ -29,6 +31,9 @@ never, never, never, never, (period), should edit this field.
 The second UDA `trellolistname` is used to determine the Trello List where
 the Card/Task is stored. You can edit this field without problems to move
 the task to another list.
+
+The third UDA, `trellomembers`, is used to store the usernames of Trello users
+who are members of the linked card.
 
 ### For TrelloWarrior
 
@@ -173,6 +178,10 @@ that define the Taskwarrior project and Trello board equivalence.
 
 * `sync_projects` MANDATORY. Define what sections are loaded, separated by spaces.
 
+* `trello_member_id_map` OPTIONAL. A string mapping Trello member IDs to
+  usernames. This will be automatically populated as needed, but names can be
+  modified if desired
+
 ### Project/Board Sections
 
 The Project/Board sections are called from `sync_projects` and define the
@@ -192,6 +201,7 @@ equivalence between Taskwarrior and Trello.
 |---------------------|---------------|
 | UDA: trelloid       | Card ID       |
 | UDA: trellolistname | List Name     |
+| UDA: trellomembers  | Members       |
 | Project             | Board Name    |
 | Description         | Card Name     |
 | Due                 | Card Due Date |

--- a/trellowarrior/clients/trello.py
+++ b/trellowarrior/clients/trello.py
@@ -122,19 +122,15 @@ class TrelloClient:
         self._board_labels.append(board_label) # Update _board_labels with new label
         return board_label
 
-    def get_card_members(self, card):
+    def get_member(self, member_id):
         """
-        Get a list of members for a Trelllo card
+        Get a Trello member by ID
 
-        :param card: a Trello API `Card` object
-        :return: a list of Trello API `Member` objects
-        :rtype: list
+        :param member_id: the member's ID
+        :return: a Trello API `Member` object
+        :rtype: `Member`
         """
-
-        return [
-            Member(self.trello_client, mid).fetch()
-            for mid in card.member_ids
-        ]
+        return Member(self.trello_client, member_id).fetch()
 
     def get_cards_dict(self):
         """

--- a/trellowarrior/clients/trello.py
+++ b/trellowarrior/clients/trello.py
@@ -148,12 +148,6 @@ class TrelloClient:
             if self._only_my_cards:
                 trello_cards_dict[trello_list.name] = filter(lambda trello_card: self.whoami in trello_card.member_ids, trello_cards_dict[trello_list.name])
 
-        # raise Exception(
-        #     [
-        #         Member(self.trello_client, mid).fetch().username
-        #                for mid in list(trello_cards_dict["Planned"])[0].member_ids
-        #     ]
-        # )
         return trello_cards_dict
 
     def delete_card(self, trello_card_id):

--- a/trellowarrior/clients/trello.py
+++ b/trellowarrior/clients/trello.py
@@ -7,7 +7,7 @@
 # Distributed under terms of the GNU GPLv3 license.
 
 from trellowarrior.exceptions import ClientError
-from trello import TrelloClient as Client
+from trello import TrelloClient as Client, Member
 from trello.exceptions import ResourceUnavailable
 
 import logging
@@ -122,6 +122,20 @@ class TrelloClient:
         self._board_labels.append(board_label) # Update _board_labels with new label
         return board_label
 
+    def get_card_members(self, card):
+        """
+        Get a list of members for a Trelllo card
+
+        :param card: a Trello API `Card` object
+        :return: a list of Trello API `Member` objects
+        :rtype: list
+        """
+
+        return [
+            Member(self.trello_client, mid).fetch()
+            for mid in card.member_ids
+        ]
+
     def get_cards_dict(self):
         """
         Get all cards of a list of Trello lists in a dictionary
@@ -137,6 +151,13 @@ class TrelloClient:
             trello_cards_dict[trello_list.name] = trello_list.list_cards()
             if self._only_my_cards:
                 trello_cards_dict[trello_list.name] = filter(lambda trello_card: self.whoami in trello_card.member_ids, trello_cards_dict[trello_list.name])
+
+        # raise Exception(
+        #     [
+        #         Member(self.trello_client, mid).fetch().username
+        #                for mid in list(trello_cards_dict["Planned"])[0].member_ids
+        #     ]
+        # )
         return trello_cards_dict
 
     def delete_card(self, trello_card_id):

--- a/trellowarrior/clients/trellowarrior.py
+++ b/trellowarrior/clients/trellowarrior.py
@@ -226,7 +226,7 @@ class TrelloWarriorClient:
             if taskwarrior_task['modified'] > trello_card.date_last_activity:
                 # Taskwarrior data is newer
                 for member_id in trello_card.member_ids:
-                    if task_member_ids and member_id not in task_member_ids:
+                    if member_id not in task_member_ids:
                         trello_card.unassign(member_id)
                 for member_id in task_member_ids:
                     if member_id not in trello_card.member_ids:

--- a/trellowarrior/clients/trellowarrior.py
+++ b/trellowarrior/clients/trellowarrior.py
@@ -54,6 +54,12 @@ class TrelloWarriorClient:
         if trello_card.labels:
             for label in trello_card.labels:
                 new_taskwarrior_task['tags'].add(label.name)
+        if trello_card.member_ids:
+            new_taskwarrior_task['trellomembers'] = ",".join([
+                member.username
+                for member in self.trello_client.get_card_members(trello_card)
+            ])
+
         new_taskwarrior_task['trelloid'] = trello_card.id
         new_taskwarrior_task['trellolistname'] = list_name
         new_taskwarrior_task.save()

--- a/trellowarrior/config.py
+++ b/trellowarrior/config.py
@@ -86,7 +86,7 @@ class Config:
                 raise MandatoryExit('trello_token_secret')
 
             try:
-                self.trello_member_id_map = config_parser.get('DEFAULT', 'trello_member_id_map', fallback=None)
+                self.trello_member_id_map = config_parser.get('DEFAULT', 'trello_member_id_map', fallback=None).strip()
             except ValueError:
                 self.trello_member_id_map = ""
 


### PR DESCRIPTION
Support addition, removal, and synchronization of Trello card members.

This PR adds a new `trellomembers` UDA that users can use to view or change the list of members attached to a Trello card.  It also uses a `trellomemberids` UDA to store the numeric IDs, since Trello usernames can change. 

A new `taskwarrior.conf` setting, `trello_member_id_map`, is used to store the member ID to name mappings, which helps limit the number of queries to the Trello API, and also allows users to change how the user name is displayed if they wish.  The setting will be created and managed automatically as new Trello members are discovered on sync.

Lightly tested, but seems to work for me.