### PR TITLE
Adding TaskWarrior task command

### DIFF
--- a/trellowarrior.conf
+++ b/trellowarrior.conf
@@ -3,6 +3,7 @@
 # Set TaskWarrior
 taskwarrior_taskrc_location = ~/.taskrc
 taskwarrior_data_location   = ~/.task
+taskwarrior_task_command    = task
 
 # Set Trello auth
 trello_api_key      = YOUR_API_KEY

--- a/trellowarrior/clients/taskwarrior.py
+++ b/trellowarrior/clients/taskwarrior.py
@@ -12,7 +12,11 @@ from tasklib.task import Task
 
 class TaskwarriorClient:
     def __init__(self, taskrc_location, data_location):
-        self.taskwarrior_client = Client(taskrc_location=taskrc_location, data_location=data_location)
+        self.taskwarrior_client = Client(
+            taskrc_location=taskrc_location,
+            data_location=data_location,
+            task_command=task_command
+        )
         self._project = None
 
     def project(self, project):

--- a/trellowarrior/clients/trellowarrior.py
+++ b/trellowarrior/clients/trellowarrior.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 
 class TrelloWarriorClient:
     def __init__(self, config):
-        self.taskwarrior_client = TaskwarriorClient(config.taskwarrior_taskrc_location, config.taskwarrior_data_location)
+        self.taskwarrior_client =
+        TaskwarriorClient(
+            config.taskwarrior_taskrc_location,
+            config.taskwarrior_data_location,
+            config.task_command
+        )
         self.trello_client = TrelloClient(config.trello_api_key, config.trello_api_secret, config.trello_token, config.trello_token_secret)
 
     def upload_taskwarrior_task(self, project, taskwarrior_task, trello_list):

--- a/trellowarrior/clients/trellowarrior.py
+++ b/trellowarrior/clients/trellowarrior.py
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 
 class TrelloWarriorClient:
     def __init__(self, config):
-        self.taskwarrior_client =
-        TaskwarriorClient(
+        self.taskwarrior_client = TaskwarriorClient(
             config.taskwarrior_taskrc_location,
             config.taskwarrior_data_location,
             config.task_command

--- a/trellowarrior/config.py
+++ b/trellowarrior/config.py
@@ -27,6 +27,7 @@ class Config:
         self.config_file = None
         self.taskwarrior_taskrc_location = None
         self.taskwarrior_data_location = None
+        self.taskwarrior_task_command = None
         self.trello_api_key = None
         self.trello_api_secret = None
         self.trello_token = None
@@ -64,6 +65,7 @@ class Config:
             # Get the TaskWarrior info from config
             self.taskwarrior_taskrc_location = config_parser.get('DEFAULT', 'taskwarrior_taskrc_location', fallback='~/.taskrc')
             self.taskwarrior_data_location = config_parser.get('DEFAULT', 'taskwarrior_data_location', fallback='~/.task')
+            self.taskwarrior_task_command = config_parser.get('DEFAULT', 'taskwarrior_task_command', fallback='task')
 
             # Get the auth info from config
             MandatoryExit = lambda option: SystemExit('Missing mandatory entry \'{}\' in config file'.format(option))


### PR DESCRIPTION
Adding TaskWarrior task command to the config. 
Is needed for crontab jobs to make sure the `task` is run correctly. 
I am setting it as `taskwarrior_task_command    = /usr/local/bin/task` in the config file, so the cronjob works, otherwise it shows me the error that `task` is not found.